### PR TITLE
Fix navigation local en

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -97,7 +97,7 @@
         :to="changePath()"
         class="btn-lang"
         ><img v-if="showEnglishMessage" src="@/assets/img/UK.png" /><img
-          v-else="showEnglishMessage"
+          v-else
           src="@/assets/img/Sweden.png"
         />
       </nuxt-link>

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -8,25 +8,69 @@
           alt="Systemvetardagen logo"
         />
       </a>
+
+
       <nav>
-        <div class="normal" v-bind:class="{ active: isActive('/') }">
-          <NuxtLink :to="localePath('/')" class="header-link">{{
-            $t("home")
-          }}</NuxtLink>
+
+        <!-- Home -->
+        <div 
+          v-if="showEnglishMessage"
+          class="normal" 
+          v-bind:class="{ active: isActive('/') }"
+          ><NuxtLink 
+            :to="localePath('/')" 
+            class="header-link">{{$t("home")}}
+          </NuxtLink>
+        </div>
+        <div 
+          v-else
+          class="normal" 
+          v-bind:class="{ active: isActive('/en/') }"
+          ><NuxtLink 
+            :to="localePath('/en') +'/'" 
+            class="header-link">{{$t("home")}}
+          </NuxtLink>
         </div>
 
         <!-- Catalog -->
-        <div class="normal" v-bind:class="{ active: isActive('/catalog/') }">
-          <NuxtLink :to="localePath('/catalog') + '/'" class="header-link">{{
-            $t("catalog")
-          }}</NuxtLink>
+        <div
+          v-if="showEnglishMessage"
+          class="normal" 
+          v-bind:class="{ active: isActive('/catalog/') }"
+          ><NuxtLink 
+            :to="localePath('/catalog') + '/'" 
+            class="header-link"
+            >{{$t("catalog")}}
+          </NuxtLink>
+        </div>
+        <div 
+          v-else
+          class="normal" 
+          v-bind:class="{ active: isActive('/en/catalog/') }"
+          ><NuxtLink 
+            :to="localePath('/en/catalog') + '/'" 
+            class="header-link">{{$t("catalog")}}
+          </NuxtLink>
         </div>
 
         <!-- About -->
-        <div v-bind:class="{ active: isActive('/about/') }" class="normal">
-          <NuxtLink :to="localePath('/about') + '/'" class="header-link">{{
-            $t("about")
-          }}</NuxtLink>
+        <div 
+          v-if="showEnglishMessage"
+          v-bind:class="{ active: isActive('/about/') }" 
+          class="normal"
+          ><NuxtLink 
+            :to="localePath('/about') + '/'" 
+            class="header-link">{{$t("about")}}
+          </NuxtLink>
+        </div>
+        <div 
+          v-else
+          v-bind:class="{ active: isActive('/en/about/') }" 
+          class="normal"
+          ><NuxtLink 
+            :to="localePath('/en/about') + '/'" 
+            class="header-link">{{$t("about")}}
+          </NuxtLink>
         </div>
       </nav>
 
@@ -94,35 +138,79 @@
     <div class="sidebar" v-if="!seen">
       <!-- Home -->
       <div
+        v-if="showEnglishMessage"
+        @click="seen = !seen"
         v-bind:class="{ mactive: isActive('/') }"
         class="mobile-header-container"
-      >
-        <NuxtLink :to="localePath('/')" class="header-link">{{
-          $t("home")
-        }}</NuxtLink>
+        ><NuxtLink 
+          :to="localePath('/')" 
+          class="header-link"
+          >{{$t("home")}}
+        </NuxtLink>
+      </div>
+      <div
+        v-else
+        @click="seen = !seen"
+        v-bind:class="{ mactive: isActive('/en') }"
+        class="mobile-header-container"
+        ><NuxtLink 
+          :to="localePath('/en')" 
+          class="header-link"
+          >{{$t("home")}}
+        </NuxtLink>
       </div>
 
       <!-- Catalog -->
       <div
         v-if="showEnglishMessage"
+        @click="seen=!seen"
         v-bind:class="{ mactive: isActive('/catalog/') }"
         class="mobile-header-container"
-      >
-        <NuxtLink :to="localePath('/catalog') + '/'" class="header-link">{{
-          $t("catalog")
-        }}</NuxtLink>
+        ><NuxtLink 
+          :to="localePath('/catalog') + '/'" 
+          class="header-link"
+          >{{$t("catalog")}}
+        </NuxtLink>
+      </div>
+      <div
+        v-else
+        @click="seen=!seen"
+        v-bind:class="{ mactive: isActive('/en/catalog/') }"
+        class="mobile-header-container"
+        ><NuxtLink 
+          :to="localePath('/en/catalog') + '/'" 
+          class="header-link"
+          >{{$t("catalog")}}
+        </NuxtLink>
       </div>
 
       <!-- About -->
       <div
         v-if="showEnglishMessage"
+        @click="seen=!seen"        
         v-bind:class="{ mactive: isActive('/about/') }"
         class="mobile-header-container"
-      >
-        <NuxtLink :to="localePath('/about') + '/'" class="header-link">{{
-          $t("about")
-        }}</NuxtLink>
+        ><NuxtLink 
+          :to="localePath('/about') + '/'" 
+          class="header-link"
+          >{{$t("about")}}
+        </NuxtLink>
       </div>
+      <div
+        v-else
+        @click="seen=!seen"        
+        v-bind:class="{ mactive: isActive('/en/about/') }"
+        class="mobile-header-container"
+        ><NuxtLink 
+          :to="localePath('/en/about') + '/'" 
+          class="header-link"
+          >{{$t("about")}}
+        </NuxtLink>
+      </div>
+
+
+
+
       <nuxt-link
         v-if="showEnglishMessage"
         :to="switchLocalePath('en')"

--- a/locales/en.json
+++ b/locales/en.json
@@ -90,7 +90,7 @@
   "programs": "Programs",
   "positions": "Positions",
   "company-contact": "Contact",
-  "go-back": "Go back",
+  "go-back": "Back to Catalog",
   "go-top": "Scroll to top",
 
   "filter-programs": [

--- a/pages/companies/_companies.vue
+++ b/pages/companies/_companies.vue
@@ -189,13 +189,24 @@
         <!-- BOTTOM BUTTONS -->
         <div class="bottom-buttons">
           <Button
+            v-if="showEnglishMessage"
             link="/companies/"
             borderCol="--crl-black"
             bColor="transparent"
             tColor="--crl-black"
             class="bb"
-            >{{ $t("go-back") }}</Button
-          >
+            >{{ $t("go-back") }}
+          </Button>
+
+          <Button
+            v-else
+            link="/en/companies/"
+            borderCol="--crl-black"
+            bColor="transparent"
+            tColor="--crl-black"
+            class="bb"
+            >{{ $t("go-back") }}
+          </Button>
 
           <Button
             link="#top"


### PR DESCRIPTION
The following issues have been fixed: 

- While on mobile, the nav side bar only displays 'home'.
- When clicking 'go back' on catalog page, the user ends up in SV locale.
- The navbar highlight bottom border doesn't show for EN locale (on desktop).

Site navigation works properly now.

I feel like I've fixed these issues a couple of times before. I would appreciate it if things didn't get deleted this time :)!