### PR TITLE
Hotfix for side menu not hiding when resizing window

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -149,7 +149,12 @@ export default {
       seen: true,
     };
   },
-
+  mounted() {
+    window.addEventListener('resize', this.handleResize);
+  },
+  unmounted() {
+    window.removeEventListener('resize', this.handleResize);
+  },
   methods: {
     isActive(cpath) {
       if (this.$route.path == cpath) {
@@ -184,6 +189,11 @@ export default {
       }
       return true;
     },
+    handleResize() { // Handles the event of resizing the window
+      if (window.innerWidth > 768) { // Width 768 is the breakpoint for mobile view
+        this.seen = true; // Seen is the variable that controls if the mobile menu is visible or not
+      }
+    }
   },
   computed: {
     showEnglishMessage() {


### PR DESCRIPTION
The NavBar prop `seen` does not change when resizing the window. Added a event listener for `resize` when the component is mounted and remove event listener when it's unmounted. Method `handleResize()` which checks if window size is greater than mobile breakpoint (768px) and switches prop value to `true` if it is which hides the window.