### PR TITLE
removed alignment in post-info css

### DIFF
--- a/pages/companies/_companies.vue
+++ b/pages/companies/_companies.vue
@@ -348,7 +348,6 @@ export default {
   display: flex;
   justify-content: center;
   flex-direction: column;
-  align-items: flex-start;
   padding: 3rem 1.5rem;
   background: var(--clr-blue-100);
   color: var(--clr-blue-900);


### PR DESCRIPTION
Removed line 351: align-items: flex-start;
In post-info CSS.
Elements in table seem to be aligning properly now.